### PR TITLE
fix 0.9.092300 版本替换 createstep.js 后无法显示页面

### DIFF
--- a/createstep.js
+++ b/createstep.js
@@ -9,7 +9,7 @@ function init() {
         r = (require("path"), require("../../utils/newReport.js")),
         i = require("../../config/urlConfig.js"),
         s = require("../../common/request/request.js"),
-        c = (require("../../stroes/webviewStores.js"), require("../../common/log/log.js")),
+        c = (require("../../stores/webviewStores.js"), require("../../common/log/log.js")),
         o = require("glob"),
         n = require("../../config/errcodeConfig.js"),
         p = (require("../../actions/windowActions.js"), require("../../actions/projectActions.js")),


### PR DESCRIPTION
建议大家直接用 0.9.092300 版本，这个版本已经不需要 0.7 版本来登录了，可以直接扫码登录
